### PR TITLE
chore(rebrand): metadata & NOTICE (no code changes)

### DIFF
--- a/NOTICE.md
+++ b/NOTICE.md
@@ -1,0 +1,9 @@
+# NOTICE
+
+This repository is an **independent fork** of upstream Uniswap code and is **not affiliated with or endorsed by Uniswap**.
+
+- Upstream source: git@github.com:Uniswap/token-lists.git
+- Copyrights and licenses remain with their respective owners.
+- See `LICENSE` for full licensing terms of this repository. Some upstream components may be under different licenses; consult upstream for details.
+
+This fork primarily changes branding and build/release metadata at this stage. Functional changes (if any) will be documented in release notes and pull requests.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Independent fork** — not affiliated with Uniswap. See NOTICE.md.
+
 # @uniswap/token-lists (beta)
 
 [![Tests](https://github.com/Uniswap/token-lists/workflows/Tests/badge.svg)](https://github.com/Uniswap/token-lists/actions?query=workflow%3ATests)

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "email": "contact@uniswap.org",
     "url": "https://uniswap.org"
   },
-  "description": "📚 The Token Lists specification",
+  "description": "Primea fork — independent fork of upstream Uniswap repo",
   "version": "1.0.0-beta.34",
   "license": "MIT",
   "main": "dist/index.js",
@@ -18,8 +18,8 @@
     "node": ">=10"
   },
   "repository": {
-    "url": "https://github.com/Uniswap/token-lists",
-    "type": "git"
+    "type": "git",
+    "url": "git+ssh://git@github.com/primeanetwork/token-lists.git"
   },
   "scripts": {
     "start": "tsdx watch",
@@ -29,7 +29,7 @@
     "lint": "tsdx lint src test",
     "prepublishOnly": "yarn test && yarn build"
   },
-  "publishConfig" : {
+  "publishConfig": {
     "access": "public",
     "provenance": true
   },
@@ -53,5 +53,9 @@
     "tsdx": "^0.14.1",
     "tslib": "^2.0.0",
     "typescript": "^4.3.5"
-  }
+  },
+  "bugs": {
+    "url": "https://github.com/primeanetwork/token-lists/issues"
+  },
+  "homepage": "https://github.com/primeanetwork/token-lists#readme"
 }


### PR DESCRIPTION
Adds `NOTICE.md`, injects an in-repo banner in `README.md`, and updates `package.json` metadata fields to point to `primeanetwork/token-lists`. **No product code changes.**